### PR TITLE
Handle manually withdrawn position

### DIFF
--- a/contracts/carrot-app/src/error.rs
+++ b/contracts/carrot-app/src/error.rs
@@ -61,7 +61,7 @@ pub enum AppError {
     NoRewards {},
 
     #[error(
-        "Failed to query position with id {0}, perhaps it got withdrawn outside of contract: {1}"
+        "Failed to query position with id {0}, perhaps it got withdrawn outside of a contract: {1}. Use create_position for a new position"
     )]
     UnableToQueryPosition(u64, StdError),
 

--- a/contracts/carrot-app/src/error.rs
+++ b/contracts/carrot-app/src/error.rs
@@ -60,6 +60,11 @@ pub enum AppError {
     #[error("No rewards for autocompound")]
     NoRewards {},
 
+    #[error(
+        "Failed to query position with id {0}, perhaps it got withdrawn outside of contract: {1}"
+    )]
+    UnableToQueryPosition(u64, StdError),
+
     #[error("Reward configuration error: {0}")]
     RewardConfigError(String),
 }

--- a/contracts/carrot-app/src/handlers/execute.rs
+++ b/contracts/carrot-app/src/handlers/execute.rs
@@ -58,7 +58,7 @@ fn create_position(
     let mut response = app.response("create_position");
     // We start by checking if there is already a position
     let funds = create_position_msg.funds;
-    let funds_to_deposit = if POSITION.exists(deps.storage) {
+    let funds_to_deposit = if get_osmosis_position(deps.as_ref()).is_ok() {
         let (withdraw_msg, withdraw_amount, total_amount, withdrawn_funds) =
             _inner_withdraw(deps.as_ref(), &env, None, &app)?;
 

--- a/contracts/carrot-app/src/state.rs
+++ b/contracts/carrot-app/src/state.rs
@@ -99,12 +99,7 @@ pub fn get_osmosis_position(deps: Deps) -> AppResult<FullPositionBreakdown> {
 
     ConcentratedliquidityQuerier::new(&deps.querier)
         .position_by_id(position.position_id)
-        .map_err(|e| {
-            cosmwasm_std::StdError::generic_err(format!(
-                "Failed to query position by id: {}\n error: {e}",
-                position.position_id
-            ))
-        })?
+        .map_err(|e| AppError::UnableToQueryPosition(position.position_id, e))?
         .position
         .ok_or(AppError::NoPosition {})
 }


### PR DESCRIPTION
This PR aims to handle cases, where user withdrawn his funds manually(outside of contract),
- For create_position - ignore not found position
- For the rest - return error that mentions manual withdraw

Closes SAVE-17. Using #11 as a base